### PR TITLE
feat(RHOAIENG-28417):added feature store code block common component

### DIFF
--- a/frontend/src/pages/featureStore/components/FeatureStoreCodeBlock.tsx
+++ b/frontend/src/pages/featureStore/components/FeatureStoreCodeBlock.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import {
+  ClipboardCopyButton,
+  CodeBlock,
+  CodeBlockAction,
+  CodeBlockCode,
+} from '@patternfly/react-core';
+
+type FeatureStoreCodeBlockProps = {
+  id: string;
+  content: string;
+  testId?: string;
+  className?: string;
+};
+
+const FeatureStoreCodeBlock: React.FC<FeatureStoreCodeBlockProps> = ({
+  id,
+  content,
+  testId,
+  className,
+}) => {
+  const [copied, setCopied] = React.useState(false);
+
+  const clipboardCopyFunc = (text: string) => {
+    navigator.clipboard.writeText(text);
+  };
+
+  const onClick = (text: string) => {
+    clipboardCopyFunc(text);
+    setCopied(true);
+  };
+
+  return (
+    <CodeBlock
+      data-testid={testId}
+      className={className}
+      actions={
+        <CodeBlockAction>
+          <ClipboardCopyButton
+            id={`${id}-button`}
+            textId={id}
+            aria-label="Copy to clipboard"
+            onClick={() => onClick(content)}
+            exitDelay={copied ? 1500 : 600}
+            maxWidth="110px"
+            variant="plain"
+            onTooltipHidden={() => setCopied(false)}
+          >
+            {copied ? 'Successfully copied to clipboard!' : 'Copy to clipboard'}
+          </ClipboardCopyButton>
+        </CodeBlockAction>
+      }
+    >
+      <CodeBlockCode id={id}>{content}</CodeBlockCode>
+    </CodeBlock>
+  );
+};
+
+export default FeatureStoreCodeBlock;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Closes [RHOAIENG-28417](https://issues.redhat.com/browse/RHOAIENG-28417)

1. Added a common component for code block

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Commits have been squashed into descriptive, self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit tests & storybook for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change (find relevant UX in the [SMEs](https://github.com/opendatahub-io/odh-dashboard/tree/main/docs/smes.md) section).

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
